### PR TITLE
Feature/3 implement minecraft server controls via crafty api service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ DISCORD_TOKEN=
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 TWITCH_USERNAME=
+TWITCH_API_BASE_URL=https://api.twitch.tv/helix
+TWITCH_AUTH_URL=https://id.twitch.tv/oauth2/token
 
 # Global API Settings
 API_MAX_RETRIES=3
@@ -17,3 +19,10 @@ LIVE_NOTIFICATION_CHECK_INTERVAL=60000 # in ms
 TOP_CLIPS_CHANNEL_ID= # Leave blank to disable
 TOP_CLIPS_SCHEDULE=0 20 * * *
 TOP_CLIP_COUNT=5
+
+# Feature: Crafty
+CRAFTY_API_TOKEN= # Leave blank to disable
+CRAFTY_API_BASE_URL=
+CRAFTY_MINECRAFT_SERVER_ID=
+CRAFTY_CHANNEL_ID= # Leave blank to everywhere
+CRAFTY_ROLE_ID= # Leave blank to everyone

--- a/README.md
+++ b/README.md
@@ -68,20 +68,29 @@ If you want your bot to run 24/7 on a server (VPS, Raspberry Pi, or dedicated se
 
 ```bash
 # Build and start the bot
-docker-compose up -d
+docker compose up -d
 
 # View logs
-docker-compose logs -f
+docker compose logs -f
 
 # Stop the bot
-docker-compose stop
+docker compose stop
 
 # Restart the bot
-docker-compose restart
+docker compose restart
 
 # Update
 git pull
-docker-compose up -d --build
+docker compose up -d --build
+```
+**If you have UFW enabled on your server and want to use the Crafty features**, you must authorize the incoming traffic on the API port (default is `8443`, use yours if different).
+
+```bash
+## If Crafty server and Bot are on the same machine
+sudo ufw allow from 172.16.0.0/12 to any port 8443 comment 'Allow Docker to Crafty'
+
+# If Crafty server and Bot are on different machines
+sudo ufw allow from [BOT_SERVER_IP] to any port 8443 comment 'Allow Remote Bot to Crafty'
 ```
 
 #### Option 2: With Node.js
@@ -146,6 +155,7 @@ The project uses a **Service-Oriented Architecture** based on separation by func
 ```bash
 twitch-alert-discord-bot/
 ├── docs/
+│   ├── CONTRIBUTING.md          # Contribution guide
 │   └── ENV_SETUP.md             # Environement setup guide
 ├── node_modules/                # Dependencies (auto-generated)
 ├── src/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You should see something like this:
 
 The project uses a **Service-Oriented Architecture** based on separation by function :
 - The **Orchestrator** `index.js` manages everything, launching specialized services for core tasks.
-- Functionalities are strictly isolated based on their runtime needs:
+- **Functionalities Services** are strictly isolated based on their runtime needs:
   - `MonitorService` handles continuous, loop-based checks.
   - `SchedulerService` manages time-based cron jobs.
 - **Communication Services** (`twitch.service.js`, `discord.service.js`) act as shared data pipelines for all features.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ These commands are prefix with mc- and are only available if the Crafty feature 
 
 | Command | Description |
 | :--- | :--- |
-| **`/mc-start`** | Sends a start signal to your Minecraft server. |
-| **`/mc-stop`** | Sends a graceful shutdown signal to the server. |
+| **`/mc-start`** | Start your Minecraft server. |
+| **`/mc-stop`** | Stop your Minecraft server. |
+| **`/mc-restart`** | Restart your Minecraft server. |
 | **`/mc-status`** | Displays real-time stats (server status, number of players). |
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Node.js Version](https://img.shields.io/badge/Node.js-v18+-339933?logo=nodedotjs)](https://nodejs.org/)
 [![Docker](https://img.shields.io/badge/Deployment-Docker-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 
-A modular Discord bot that sends automatic "Live notifications" and daily "Top Clips" digests to your server.
+A modular Discord bot that sends automatic "Live notifications" and daily "Top Clips" digests to your server. You can also use discord commands to start, stop and restart a local crafty minecraft server.
 
 ## Table of Contents
 
@@ -30,6 +30,7 @@ A modular Discord bot that sends automatic "Live notifications" and daily "Top C
 * **Modular**: Easily enable or disable features like live alerts or clips directly from the configuration.
 * **No Spam**: Only one notification per stream, and one clip digest per day.
 * **Configurable**: Set check intervals, API timeouts, and cron schedules.
+* **Crafty Controller Integration**: Manage your Minecraft server directly from Discord with slash commands (/mc-start, /mc-stop, /mc-status).
 
 ## Quick Start
 
@@ -104,6 +105,8 @@ You should see something like this:
 [dotenv@17.2.3] injecting env (6) from .env -- tip: ⚙️  write to custom object with { processEnv: myObject }
 [11/03/2025 10:00:01] [SUCCESS] Configuration validated
 [11/03/2025 10:00:02] [SUCCESS] Discord bot connected as YourBot#1234
+[11/03/2025 10:00:02] [INFO] [DISCORD] Refreshing slash commands...
+[11/03/2025 10:00:02] [SUCCESS] [DISCORD] Slash commands registered.
 [11/03/2025 10:00:02] [MONITOR] Monitoring your_channel every 60000ms
 [11/03/2025 10:00:02] [SCHEDULER] Scheduling daily clips job with schedule: 0 20 * * *
 [11/03/2025 10:00:03] [SUCCESS] Twitch access token obtained
@@ -111,6 +114,20 @@ You should see something like this:
 ```
 
 **To stop the bot:** Press `Ctrl + C` in the terminal
+
+## Commands Usage
+
+The bot uses Discord Slash Commands. These commands are registered automatically when the bot starts.
+
+### Crafty (Minecraft) Commands
+
+These commands are prefix with mc- and are only available if the Crafty feature is enabled.
+
+| Command | Description |
+| :--- | :--- |
+| **`/mc-start`** | Sends a start signal to your Minecraft server. |
+| **`/mc-stop`** | Sends a graceful shutdown signal to the server. |
+| **`/mc-status`** | Displays real-time stats (server status, number of players). |
 
 ## Project Structure
 
@@ -134,6 +151,7 @@ twitch-alert-discord-bot/
 │   ├── config/
 │   │   └── index.js             # Configuration and validation
 │   ├── services/
+│   │   ├── crafty.service.js    # Crafty API (Minecraft) integration
 │   │   ├── discord.service.js   # Discord API integration
 │   │   ├── monitor.service.js   # Continuous status checking
 │   │   ├── scheduler.service.js # Time-based job scheduling
@@ -156,8 +174,7 @@ twitch-alert-discord-bot/
 
 ## Security
 
-- Never share or commityour `.env` file
-- Never share your `DISCORD_TOKEN` or `TWITCH_CLIENT_SECRET`
+- Never share or commit your `.env` file
 - If you accidentally expose a token, regenerate it immediately
 
 ## License
@@ -166,4 +183,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) f
 
 ## Contributing
 
-Feel free to fork this project and submit pull requests with improvements!
+Everyone is welcome to contribute to this project! You don't need to be a developer to help out:
+
+- **Share your feedback**: Use the issues to discuss your user experience or suggest improvements.
+- **Report a bug**: If something isn't working, let me know by opening an issue.
+- **Request a feature**: Have an idea for a new tool? I'd love to hear about it. Open a new issue.
+- **Code**: Whether you want to fix a bug or build a new feature, you can pick up an existing issue or propose a new one.
+
+For technical details on how to set up the project and our coding standards, please read our [Contributing Guidelines](docs/CONTRIBUTING.md).
+
+Check the [Issues](https://github.com/hugo-lanzafame/twitch-alert-discord-bot/issues) page to see what's currently being worked on.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   twitch-alert-discord-bot:
     build: .
@@ -9,7 +7,12 @@ services:
       - .env
     environment:
       - NODE_ENV=production
-      - NODE_TLS_REJECT_UNAUTHORIZED=0
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     dns:
       - 8.8.8.8
       - 8.8.4.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     environment:
       - NODE_ENV=production
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
     dns:
       - 8.8.8.8
       - 8.8.4.4

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guidelines
+
+First off, thank you for taking the time to contribute!
+
+## Development Workflow
+
+To maintain a clean and logical project history, we follow a strict "Issue-First" workflow:
+
+### 1. The Issue is Key
+- **No Pull Request will be merged without an associated Issue.**
+- If you want to work on something, check the [Issues](https://github.com/hugo-lanzafame/twitch-alert-discord-bot/issues) page. 
+- If the task doesn't exist, create a new Issue to discuss it before starting to code.
+
+### 2. Branch Naming Convention
+
+| Prefix | Description
+| :--- | :--- |
+| `feature/` | New features or UI additions
+| `bugfix/` | Bug fixes
+| `doc/` | Documentation updates
+| `refactor/` | Code cleanup or optimization
+
+
+After the prefix, use the Issue ID followed by a short, kebab-case description of the task.
+
+**Format:** prefix/id-description
+
+**Examples:** 
+- feature/12-twitch-id-validation
+- bugfix/45-fix-timeout-error
+- refactor/8-optimize-orchestrator
+
+### 3. Submitting a Pull Request
+1. Fork the repository and create your branch from `master`.
+2. Ensure your code is clean and matches the project's style.
+3. Just before submmiting, pull `master` to resolve potentials merges.
+3. In your PR description, use a keyword to link and close the issue (e.g., `Closes #12`).
+4. Once submitted, your PR will be reviewed as soon as possible!
+
+## Versioning & Releases
+
+We use [Semantic Versioning (SemVer)](https://semver.org/) for this project:
+- **Major** (x.0.0): Breaking changes.
+- **Minor** (0.x.0): New features (backwards compatible).
+- **Patch** (0.0.x): Bug fixes (backwards compatible).
+
+Tags and Releases are created by the maintainer. A new version is tagged on the `master` branch as soon as a significant set of changes (features or bug fixes) is merged.

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -114,13 +114,20 @@ If you plan to use the Minecraft server control features, you will need to link 
 
     - Login to your Crafty Panel.
     - Go to Settings > API Tokens.
-    - Generate a new token with `COMMANDS` and `PLAYERS` permissions.
+    - Generate a new token with `Superuser` permission.
     - Paste it into the corresponding variable in your `.env`.
     - Leave blank to **disable** crafty feature. 
 
 2. **CRAFTY_API_BASE_URL**
 
-    This is the root URL of your Crafty API. It usually follows this format: `https://[YOUR_IP]:[PORT]/api/v2`.
+    This is the root URL of your Crafty API. It usually follows this format: `https://[YOUR_IP]:[PORT]/api/v2`. 
+    The `YOUR_IP` you should use depends on how you are running the bot:
+
+      | Setup | YOUR_IP | Reason |
+      | :--- | :--- | :--- |
+      | **Bot in Docker (Same machine)** | `host.docker.internal` | Allows the container to "exit" its virtual network to reach the host's Crafty API. |
+      | **Bot in Node.js (Same machine)** | `localhost` or `127.0.0.1` | The bot and Crafty share the same local network interface. |
+      | **Different Machines** | `192.168.1.XX` (Local IP) | Use the actual LAN IP of the machine where Crafty is installed. |
 
 3. **CRAFTY_MINECRAFT_SERVER_ID**
 

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -62,9 +62,15 @@ Use **lowercase** letters only!
 
 ## Channel and Feature Configuration
 
+This bot is modular. You only need to configure the variables for the features you actually want to use.
+- To enable a feature: Fill in all its specific variables.
+- To disable a feature: Leave its variables blank (or remove them).
+
+Only complete the sections that match your specific use case.
+
 ### Finding a Discord Channel ID
 
-You will need the Channel ID for live alerts (`LIVE_NOTIFICATION_CHANNEL_ID`) and for daily clips (`TOP_CLIPS_CHANNEL_ID`).
+You will need the Channel ID for live alerts (`LIVE_NOTIFICATION_CHANNEL_ID`), for daily clips (`TOP_CLIPS_CHANNEL_ID`) and for crafty (`CRAFTY_CHANNEL_ID`).
 
 1.  **Enable Developer Mode in Discord:**
       * Open Discord User Settings.
@@ -78,14 +84,68 @@ You will need the Channel ID for live alerts (`LIVE_NOTIFICATION_CHANNEL_ID`) an
 
 **IMPORTANT:** Ensure your bot has the `Send Messages`, `Embed Links`, and `Mention Everyone` permissions in the selected channel.
 
-### Channel Variables
+#### Channel Variables
 
   * **`LIVE_NOTIFICATION_CHANNEL_ID`**: The ID of the channel where the bot should post **LIVE** stream alerts. Leave blank to **disable** this feature.
   * **`TOP_CLIPS_CHANNEL_ID`**: The ID of the channel where the bot should post the **Top Clips** digest. Leave blank to **disable** this feature.
+  * **`CRAFTY_CHANNEL_ID`**: The ID of the channel where users can use the crafty commands. Leave blank to allow commands **everywere**.
 
-## Optional Settings
+### Finding a Discord Role ID
 
-### Global API and Monitoring
+You will need the Role ID for crafty (`CRAFTY_ROLE_ID`).
+
+1.  **Enable Developer Mode in Discord:**
+      * Already activated for [Discord Channel ID](#finding-a-discord-channel-id)
+2.  **Get the Channel ID:**
+      * Go to your Discord server settings.
+      * Go to **"Roles"**.
+      * Right-click on the role name and click **"Copy Role ID"**.
+      * Paste this ID into the corresponding variable in your `.env`.
+
+#### Role Variables
+
+  * **`CRAFTY_ROLE_ID`**: The ID of the role allowed to use crafty commands. Leave blank to allow **everyone** to use these commands.
+
+### Crafty Configuration
+
+If you plan to use the Minecraft server control features, you will need to link the bot to your **Crafty Controller** instance.
+
+1. **CRAFTY_API_TOKEN**
+
+    - Login to your Crafty Panel.
+    - Go to Settings > API Tokens.
+    - Generate a new token with `COMMANDS` and `PLAYERS` permissions.
+    - Paste it into the corresponding variable in your `.env`.
+    - Leave blank to **disable** crafty feature. 
+
+2. **CRAFTY_API_BASE_URL**
+
+    This is the root URL of your Crafty API. It usually follows this format: `https://[YOUR_IP]:[PORT]/api/v2`.
+
+3. **CRAFTY_MINECRAFT_SERVER_ID**
+
+    - Login to your Crafty Panel.
+    - Click on the specific Minecraft server you want to control.
+    - Check the URL in your browser; the ID is the string of characters at the very end.
+    
+    ``` bash
+    # the ID is 609f07bc-2144-43c0-a1ae-1a91b4add919
+    https://.../panel/server_detail?id=609f07bc-2144-43c0-a1ae-1a91b4add919
+    ```
+
+## Others Settings
+
+### Global Configuration
+
+These variables are the core of your bot. They are mandatory for the application to authenticate with Discord and Twitch.
+
+| Variable | Description | Default Value |
+| :--- | :--- | :--- |
+| **`TWITCH_API_BASE_URL`** | The base entry point for Twitch Helix API requests. | `https://api.twitch.tv/helix` |
+| **`TWITCH_AUTH_URL`** | The endpoint used to generate the OAuth2 access token. | `https://id.twitch.tv/oauth2/token` |
+
+
+### Global API Settings
 
 These settings control the robustness and frequency of API requests.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,42 +10,139 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",
-        "discord.js": "^13.17.1",
+        "discord.js": "^14.16.3",
         "dotenv": "^17.2.3",
         "node-cron": "^4.2.1"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-      "deprecated": "no longer supported",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
-      "license": "MIT"
-    },
     "node_modules/@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "deprecated": "no longer supported",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@sapphire/async-queue": {
@@ -59,9 +156,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.7.tgz",
-      "integrity": "sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -69,6 +166,16 @@
       },
       "engines": {
         "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -80,16 +187,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -99,6 +196,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -106,9 +213,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -151,31 +258,39 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
-      "license": "MIT"
+      "version": "0.38.37",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
+      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/discord.js": {
-      "version": "13.17.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.17.1.tgz",
-      "integrity": "sha512-h13kUf+7ZaP5ZWggzooCxFutvJJvugcAO54oTEIdVr3zQWi0Sf/61S1kETtuY9nVAyYebXR/Ey4C+oWbsgEkew==",
-      "deprecated": "Version 13 is no longer supported.",
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^0.16.0",
-        "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/node-fetch": "^2.6.3",
-        "@types/ws": "^8.5.4",
-        "discord-api-types": "^0.33.5",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.6.0",
-        "npm": ">=7.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dotenv": {
@@ -276,9 +391,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -394,6 +509,18 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -433,36 +560,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/ts-mixer": {
@@ -477,27 +578,20 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,145 +1,51 @@
 {
   "name": "discord-bot",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "2.0.0",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",
-        "discord.js": "^14.23.2",
+        "discord.js": "^13.17.1",
         "dotenv": "^17.2.3",
         "node-cron": "^4.2.1"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.12.2.tgz",
-      "integrity": "sha512-AugKmrgRJOHXEyMkABH/hXpAmIBKbYokCEl9VAM4Kh6FvkdobQ+Zhv7AR6K+y5hS7+VQ7gKXPYCe1JQmV07H1g==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "deprecated": "no longer supported",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.26",
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.4",
-        "tslib": "^2.6.3"
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
+        "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "license": "MIT"
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "deprecated": "no longer supported",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@discordjs/formatters": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
-      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "discord-api-types": "^0.38.1"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
-      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.16",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
-      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@types/ws": "^8.5.10",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "^0.38.1",
-        "tslib": "^2.6.2",
-        "ws": "^8.17.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@sapphire/async-queue": {
@@ -153,9 +59,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.7.tgz",
+      "integrity": "sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -165,23 +71,23 @@
         "node": ">=v16"
       }
     },
-    "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.14.0"
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/ws": {
@@ -191,16 +97,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
-      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -255,39 +151,31 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.30",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.30.tgz",
-      "integrity": "sha512-KhAqlBrg+rVK+Ob7INMF5o63yW4/GUzRatG/AjyVsIO8lgcLyR8qCl2HokIVzWwmzkJYG0CEPXsKMOqau3E8NA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
+      "license": "MIT"
     },
     "node_modules/discord.js": {
-      "version": "14.23.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.23.2.tgz",
-      "integrity": "sha512-tU2NFr823X3TXEc8KyR/4m296KLxPai4nirN3q9kHCpY4TKj96n9lHZnyLzRNMui8EbL07jg9hgH2PWWfKMGIg==",
+      "version": "13.17.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.17.1.tgz",
+      "integrity": "sha512-h13kUf+7ZaP5ZWggzooCxFutvJJvugcAO54oTEIdVr3zQWi0Sf/61S1kETtuY9nVAyYebXR/Ey4C+oWbsgEkew==",
+      "deprecated": "Version 13 is no longer supported.",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.12.1",
-        "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/rest": "^2.6.0",
-        "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.29",
-        "fast-deep-equal": "3.1.3",
-        "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "@discordjs/builders": "^0.16.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/node-fetch": "^2.6.3",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.33.5",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.7",
+        "ws": "^8.13.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -501,21 +389,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "license": "MIT"
-    },
-    "node_modules/magic-bytes.js": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
-      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -557,10 +433,36 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/ts-mixer": {
@@ -575,25 +477,32 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
       "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/formatters": "^0.6.2",
         "@discordjs/util": "^1.2.0",
@@ -40,7 +39,6 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
       "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.11.0"
       }
@@ -49,7 +47,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
       "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "discord-api-types": "^0.38.33"
       },
@@ -64,7 +61,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
       "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
         "@discordjs/util": "^1.2.0",
@@ -87,7 +83,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
       "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       },
@@ -99,7 +94,6 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
       "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -109,7 +103,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
       "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "discord-api-types": "^0.38.33"
       },
@@ -124,7 +117,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
       "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.0",
         "@discordjs/rest": "^2.5.1",
@@ -147,7 +139,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
       "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       },
@@ -159,7 +150,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
       "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
-      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -169,7 +159,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
       "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
@@ -182,17 +171,15 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
       "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "license": "MIT",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -201,7 +188,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -210,7 +196,6 @@
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
       "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
-      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -219,16 +204,14 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -237,7 +220,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -250,7 +232,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -262,7 +243,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -270,17 +250,12 @@
     "node_modules/discord-api-types": {
       "version": "0.38.47",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
-      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="
     },
     "node_modules/discord.js": {
-      "version": "14.26.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.3.tgz",
-      "integrity": "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==",
-      "license": "Apache-2.0",
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
@@ -307,7 +282,6 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -319,7 +293,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -333,7 +306,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -342,7 +314,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -351,7 +322,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -363,7 +333,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -377,8 +346,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -390,7 +358,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -404,7 +371,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -420,7 +386,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -429,7 +394,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -453,7 +417,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -466,7 +429,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -478,7 +440,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -490,7 +451,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -502,10 +462,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -516,26 +475,22 @@
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "license": "MIT"
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/magic-bytes.js": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
-      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
-      "license": "MIT"
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -544,7 +499,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -553,7 +507,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -565,7 +518,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
       "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
-      "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -574,7 +526,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -582,20 +533,17 @@
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "license": "MIT",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "engines": {
         "node": ">=18.17"
       }
@@ -603,14 +551,12 @@
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT"
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
     },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
   "description": "A Discord bot that sends automatic live notifications and daily top clips from Twitch",
   "dependencies": {
     "axios": "^1.12.2",
-    "discord.js": "^13.17.1",
+    "discord.js": "^14.16.3",
     "dotenv": "^17.2.3",
     "node-cron": "^4.2.1"
+  },
+  "overrides": {
+    "undici": "^6.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,19 @@
     "start": "node src/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["discord", "bot", "twitch", "notifications", "clips"],
+  "keywords": [
+    "discord",
+    "bot",
+    "twitch",
+    "notifications",
+    "clips"
+  ],
   "author": "hugo-lanzafame",
   "license": "MIT",
   "description": "A Discord bot that sends automatic live notifications and daily top clips from Twitch",
   "dependencies": {
     "axios": "^1.12.2",
-    "discord.js": "^14.23.2",
+    "discord.js": "^13.17.1",
     "dotenv": "^17.2.3",
     "node-cron": "^4.2.1"
   }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,8 +9,10 @@ const CONFIG = {
         clientId: process.env.TWITCH_CLIENT_ID,
         clientSecret: process.env.TWITCH_CLIENT_SECRET,
         username: process.env.TWITCH_USERNAME?.toLowerCase(),
+        apiBaseUrl: process.env.TWITCH_API_BASE_URL,
+        authUrl: process.env.TWITCH_AUTH_URL,
     },
-    api: {
+    apiSettings: {
         maxRetries: parseInt(process.env.API_MAX_RETRIES || '3', 10),
         retryDelay: parseInt(process.env.API_RETRY_DELAY || '2000', 10),
         requestTimeout: parseInt(process.env.API_REQUEST_TIMEOUT || '10000', 10),
@@ -31,6 +33,15 @@ const CONFIG = {
             schedule: process.env.TOP_CLIPS_SCHEDULE || '0 20 * * *',
             count: parseInt(process.env.TOP_CLIP_COUNT || '5', 10),
         },
+        crafty: {
+            // Feature is enabled IF the channelId is provided
+            isEnabled: !!process.env.CRAFTY_API_TOKEN,
+            apiToken: process.env.CRAFTY_API_TOKEN,
+            apiBaseUrl: process.env.CRAFTY_API_BASE_URL,
+            minecraftServerId: process.env.CRAFTY_MINECRAFT_SERVER_ID,
+            channelId: process.env.CRAFTY_CHANNEL_ID,
+            roleId: process.env.CRAFTY_ROLE_ID,
+        }
     },
 };
 
@@ -44,6 +55,8 @@ function validateConfig() {
         'TWITCH_CLIENT_ID',
         'TWITCH_CLIENT_SECRET',
         'TWITCH_USERNAME',
+        'TWITCH_API_BASE_URL',
+        'TWITCH_AUTH_URL',
         'API_MAX_RETRIES',
         'API_RETRY_DELAY',
         'API_REQUEST_TIMEOUT',
@@ -61,6 +74,14 @@ function validateConfig() {
             'TOP_CLIPS_CHANNEL_ID',
             'TOP_CLIPS_SCHEDULE',
             'TOP_CLIP_COUNT'
+        );
+    }
+
+    if (CONFIG.features.crafty.isEnabled) {
+        requiredKeys.push(
+            'CRAFTY_API_TOKEN',
+            'CRAFTY_API_BASE_URL',
+            'CRAFTY_MINECRAFT_SERVER_ID',
         );
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
-const { CONFIG, validateConfig } = require('./config');
+const { validateConfig } = require('./config');
 const TwitchService = require('./services/twitch.service');
 const DiscordService = require('./services/discord.service');
 const SchedulerService = require('./services/scheduler.service');
-const MonitorService = require('./services/monitor.service'); // New Monitor Service
+const MonitorService = require('./services/monitor.service');
+const CraftyService = require('./services/crafty.service');
 const Logger = require('./utils/logger');
 
 /**
@@ -10,11 +11,12 @@ const Logger = require('./utils/logger');
  */
 class BotOrchestrator {
     constructor() {
-        // Initialize Core Services
+        // Initialize Communication Services
         this.twitchService = new TwitchService();
-        this.discordService = new DiscordService();
+        this.craftyService = new CraftyService();
+        this.discordService = new DiscordService(this.craftyService);
         
-        // Initialize Feature Services (Dependency Injection)
+        // Initialize Functionalities Services
         this.monitorService = new MonitorService(this.twitchService, this.discordService);
         this.schedulerService = new SchedulerService(this.twitchService, this.discordService); 
     }

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -1,0 +1,95 @@
+const axios = require('axios');
+const { CONFIG } = require('../config');
+const Logger = require('../utils/logger');
+const { withRetry } = require('../utils/retry');
+
+const CRAFTY_ACTIONS = {
+    START: 'start',
+    STOP: 'stop',
+    RESTART: 'restart'
+};
+
+/**
+ * Service to interact with Crafty API
+ */
+class CraftyService {
+    constructor() {
+        this.apiBaseUrl = CONFIG.features.crafty.apiBaseUrl;
+        this.apiToken = CONFIG.features.crafty.apiToken;
+        this.minecraftServerId = CONFIG.features.crafty.minecraftServerId;
+
+        this.api = axios.create({
+            baseURL: this.apiBaseUrl,
+            headers: {
+                'Authorization': `Bearer ${this.apiToken}`,
+                'Content-Type': 'application/json'
+            },
+            timeout: CONFIG.apiSettings.requestTimeout
+        });
+    }
+
+    /**
+     * Run an action (start/stop/restart) on the Minecraft server.
+     * @param {string} action 
+     * @returns {Promise<Object>}
+     */
+    async runAction(action) {
+        return await withRetry(
+            async () => {
+                const response = await this.api.post(`/servers/${this.minecraftServerId}/action/${action}`);
+                Logger.success(`[CRAFTY] Action ${action} sent to minecraft server`);
+                return response.data;
+            },
+            {
+                maxRetries: CONFIG.apiSettings.maxRetries,
+                baseDelay: CONFIG.apiSettings.retryDelay
+            }
+        );
+    }
+
+    /**
+     * Start the Minecraft server
+     */
+    async startMinecraftServer() {
+        return await this.runAction(CRAFTY_ACTIONS.START);
+    }
+
+    /**
+     * Stop the minecraft server
+     */
+    async stopMinecraftServer() {
+        return await this.runAction(CRAFTY_ACTIONS.STOP);
+    }
+
+    /**
+     * Restart the minecraft server
+     */
+    async restartMinecraftServer() {
+        return await this.runAction(CRAFTY_ACTIONS.RESTART);
+    }
+
+    /**
+     * Retrieves statistics from the server
+     * @returns {Promise<Object>}
+     */
+    async getMinecraftServerInfo() {
+        try {
+            return await withRetry(
+                async () => {
+                    const response = await this.api.get(`/servers/${this.minecraftServerId}/stats`);
+                    Logger.success(`[CRAFTY] Stats retrieves from minecraft server`);
+                    return response.data;
+                },
+                {
+                    maxRetries: CONFIG.apiSettings.maxRetries,
+                    baseDelay: CONFIG.apiSettings.retryDelay
+                }
+            );
+        } catch (error) {
+            Logger.error(`[CRAFTY] Failed to fetch server stats: ${error.message}`);
+            throw error;
+        }
+    }
+}
+
+module.exports = CraftyService;

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -23,10 +23,11 @@ class CraftyService {
         this.api = axios.create({
             baseURL: this.apiBaseUrl,
             httpsAgent: new https.Agent({
-                rejectUnauthorized: false
+                rejectUnauthorized: false,
+                keepAlive: true,
             }),
             headers: {
-                'Authorization': `Bearer ${this.apiToken}`,
+                'X-Crafty-Token': `Bearer ${this.apiToken}`,
                 'Content-Type': 'application/json'
             },
             timeout: CONFIG.apiSettings.requestTimeout
@@ -39,13 +40,24 @@ class CraftyService {
      * @returns {Promise<Object>}
      */
     async runAction(action) {
-        return await withRetry(
-            async () => {
-                const response = await this.api.post(`/servers/${this.minecraftServerId}/action/${action}`);
-                Logger.success(`[CRAFTY] Action ${action} sent to minecraft server`);
-                return response.data;
-            },
-        );
+        const executeRequest = async () => {
+            const response = await this.api.post(
+                `/servers/${this.minecraftServerId}/action/${action}`,
+                {},
+                { timeout: 60000  }
+            );
+            Logger.success(`[CRAFTY] Action ${action} successfully sent`);
+            return response.data;
+        };
+
+        if (action === CRAFTY_ACTIONS.START) {
+            return await executeRequest();
+        }
+        
+        return await withRetry(executeRequest, {
+            maxRetries: CONFIG.apiSettings.maxRetries,
+            baseDelay: CONFIG.apiSettings.retryDelay,
+        });
     }
 
     /**

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -27,7 +27,7 @@ class CraftyService {
                 keepAlive: true,
             }),
             headers: {
-                'X-Crafty-Token': `Bearer ${this.apiToken}`,
+                'X-Crafty-Token': this.apiToken,
                 'Content-Type': 'application/json'
             },
             timeout: CONFIG.apiSettings.requestTimeout

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -18,8 +18,13 @@ class CraftyService {
         this.apiToken = CONFIG.features.crafty.apiToken;
         this.minecraftServerId = CONFIG.features.crafty.minecraftServerId;
 
+        const https = require('https');
+
         this.api = axios.create({
             baseURL: this.apiBaseUrl,
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false
+            }),
             headers: {
                 'Authorization': `Bearer ${this.apiToken}`,
                 'Content-Type': 'application/json'

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -45,10 +45,6 @@ class CraftyService {
                 Logger.success(`[CRAFTY] Action ${action} sent to minecraft server`);
                 return response.data;
             },
-            {
-                maxRetries: CONFIG.apiSettings.maxRetries,
-                baseDelay: CONFIG.apiSettings.retryDelay
-            }
         );
     }
 

--- a/src/services/crafty.service.js
+++ b/src/services/crafty.service.js
@@ -4,9 +4,9 @@ const Logger = require('../utils/logger');
 const { withRetry } = require('../utils/retry');
 
 const CRAFTY_ACTIONS = {
-    START: 'start',
-    STOP: 'stop',
-    RESTART: 'restart'
+    START: 'start_server',
+    STOP: 'stop_server',
+    RESTART: 'restart_server'
 };
 
 /**
@@ -27,7 +27,7 @@ class CraftyService {
                 keepAlive: true,
             }),
             headers: {
-                'X-Crafty-Token': this.apiToken,
+                'Authorization': `Bearer ${this.apiToken}`,
                 'Content-Type': 'application/json'
             },
             timeout: CONFIG.apiSettings.requestTimeout

--- a/src/services/discord.service.js
+++ b/src/services/discord.service.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits, EmbedBuilder } = require('discord.js');
+const { Client, GatewayIntentBits, EmbedBuilder, REST, Routes, SlashCommandBuilder } = require('discord.js');
 const { CONFIG } = require('../config');
 const Logger = require('../utils/logger');
 
@@ -6,12 +6,25 @@ const Logger = require('../utils/logger');
  * Service to interact with Discord API
  */
 class DiscordService {
-    constructor() {
+    /**
+     * @param {import('./crafty.service')} craftyService
+     */
+    constructor(craftyService) {
+        this.craftyService = craftyService;
+
+        this.discordToken = CONFIG.discord.token;
+        this.twitchUsername = CONFIG.twitch.username;
+        this.liveNotificationChannelId = CONFIG.features.liveNotification.channelId;
+        this.topClipsChannelId = CONFIG.features.topClips.channelId;
+        this.craftyIsEnabled = CONFIG.features.crafty.isEnabled;
+        this.craftyRoleId = CONFIG.features.crafty.roleId;
+
         this.client = new Client({
             intents: [GatewayIntentBits.Guilds]
         });
-        
+
         this.isReady = false;
+        this.commands = new Map();
         this.setupEventHandlers();
     }
 
@@ -19,9 +32,18 @@ class DiscordService {
      * Setup Discord client event handlers
      */
     setupEventHandlers() {
-        this.client.once('clientReady', () => {
+        this.client.once('clientReady', async () => {
             this.isReady = true;
             Logger.success(`Discord bot connected as ${this.client.user.tag}`);
+            await this.registerSlashCommands();
+        });
+
+        this.client.on('interactionCreate', async (interaction) => {
+            if (!interaction.isChatInputCommand()) {
+                return;
+            }
+
+            await this.handleInteraction(interaction);
         });
 
         this.client.on('error', (error) => {
@@ -35,7 +57,7 @@ class DiscordService {
      */
     async login() {
         try {
-            await this.client.login(CONFIG.discord.token);
+            await this.client.login(this.discordToken);
         } catch (error) {
             Logger.error('Failed to login to Discord:', error.message);
 
@@ -61,13 +83,105 @@ class DiscordService {
      */
     async waitUntilReady(timeout = 10000) {
         const startTime = Date.now();
-        
+
         while (!this.isReady) {
             if (Date.now() - startTime > timeout) {
                 throw new Error('Discord client ready timeout');
             }
+
             await new Promise(resolve => setTimeout(resolve, 100));
         }
+    }
+
+    /**
+     * Register commands dynamically
+     */
+    async registerSlashCommands() {
+        const commandList = [];
+
+        // Feature: Crafty
+        if (this.craftyIsEnabled) {
+            commandList.push(
+                new SlashCommandBuilder().setName('mc-start').setDescription('Start Minecraft server'),
+                new SlashCommandBuilder().setName('mc-stop').setDescription('Stop Minecraft server'),
+                new SlashCommandBuilder().setName('mc-status').setDescription('Check Minecraft server status')
+            );
+        }
+
+        const rest = new REST({ version: '10' }).setToken(this.discordToken);
+
+        try {
+            Logger.info('[DISCORD] Refreshing slash commands...');
+            await rest.put(
+                Routes.applicationCommands(this.client.user.id),
+                { body: commandList.map(c => c.toJSON()) },
+            );
+            Logger.success('[DISCORD] Slash commands registered.');
+        } catch (error) {
+            Logger.error('[DISCORD] Failed to register commands:', error);
+        }
+    }
+
+    /**
+     * Interaction dispatcher
+     */
+    async handleInteraction(interaction) {
+        const { commandName } = interaction;
+
+        // Feature: Crafty
+        if (commandName.startsWith('mc-')) {
+            if (!this.craftyIsEnabled) {
+                return interaction.reply({ content: 'This feature is disabled.', ephemeral: true });
+            }
+
+            if (this.craftyRoleId && !interaction.member.roles.cache.has(this.craftyRoleId)) {
+                return interaction.reply({ content: 'You don\'t have the right role for this.', ephemeral: true });
+            }
+
+            return this.handleCraftyCommand(interaction);
+        }
+    }
+
+    /**
+     * Crafty command handler
+     */
+    async handleCraftyCommand(interaction) {
+        const { commandName } = interaction;
+        await interaction.deferReply();
+
+        try {
+            switch (commandName) {
+                case 'mc-start':
+                    await this.craftyService.startMinecraftServer();
+                    await interaction.editReply('Minecraft server starting up...');
+                    break;
+                case 'mc-stop':
+                    await this.craftyService.stopMinecraftServer();
+                    await interaction.editReply('Minecraft server shutdown...');
+                    break;
+                case 'mc-status':
+                    const stats = await this.craftyService.getMinecraftServerInfo();
+                    await interaction.editReply({ embeds: [this.buildMinecraftStatusEmbed(stats)] });
+                    break;
+            }
+        } catch (error) {
+            Logger.error(`[CRAFTY] Error: ${error.message}`);
+            await interaction.editReply('Technical error with the Minecraft server.');
+        }
+    }
+
+    /**
+     * Embed builder for minecraft server status
+     */
+    buildMinecraftStatusEmbed(stats) {
+        return new EmbedBuilder()
+            .setColor(stats.running ? '#2ecc71' : '#e74c3c')
+            .setTitle('Minecraft server')
+            .addFields(
+                { name: 'Statut', value: stats.running ? 'Online' : 'Offline', inline: true },
+                { name: 'Players', value: `${stats.online_players || 0}/${stats.max_players || 0}`, inline: true }
+            )
+            .setTimestamp();
     }
 
     /**
@@ -81,10 +195,10 @@ class DiscordService {
                 throw new Error('Discord client is not ready');
             }
 
-            const channel = await this.client.channels.fetch(CONFIG.features.liveNotification.channelId);
-            
+            const channel = await this.client.channels.fetch(this.liveNotificationChannelId);
+
             if (!channel) {
-                throw new Error(`Live channel ${CONFIG.features.liveNotification.channelId} not found`);
+                throw new Error(`Live channel ${this.liveNotificationChannelId} not found`);
             }
 
             if (!channel.isTextBased()) {
@@ -120,17 +234,17 @@ class DiscordService {
             .setColor('#9146FF')
             .setTitle(`🔴 ${streamData.user_name} is LIVE!`)
             .setDescription(streamData.title || 'No description')
-            .setURL(`https://twitch.tv/${CONFIG.twitch.username}`)
+            .setURL(`https://twitch.tv/${this.twitchUsername}`)
             .addFields(
-                { 
-                    name: '🎮 Game', 
-                    value: streamData.game_name || 'Not specified', 
-                    inline: true 
+                {
+                    name: '🎮 Game',
+                    value: streamData.game_name || 'Not specified',
+                    inline: true
                 },
-                { 
-                    name: '👥 Viewers', 
-                    value: streamData.viewer_count?.toString() || '0', 
-                    inline: true 
+                {
+                    name: '👥 Viewers',
+                    value: streamData.viewer_count?.toString() || '0',
+                    inline: true
                 }
             )
             .setImage(thumbnailUrl)
@@ -149,10 +263,10 @@ class DiscordService {
                 throw new Error('Discord client is not ready');
             }
 
-            const channel = await this.client.channels.fetch(CONFIG.features.topClips.channelId);
+            const channel = await this.client.channels.fetch(this.topClipsChannelId);
 
             if (!channel) {
-                throw new Error(`Clips channel ${CONFIG.features.topClips.channelId} not found`);
+                throw new Error(`Clips channel ${this.topClipsChannelId} not found`);
             }
 
             if (!channel.isTextBased()) {
@@ -194,16 +308,16 @@ class DiscordService {
             });
         });
 
-        const description = `We've got the Top **${clips.length}** clips from **${CONFIG.twitch.username}** over the last 24 hours! Check out the best moments below.`;
+        const description = `We've got the Top **${clips.length}** clips from **${this.twitchUsername}** over the last 24 hours! Check out the best moments below.`;
         const thumbnailUrl = clips[0]?.thumbnail_url.replace('-preview-480x272.jpg', '.jpg') || '';
 
         return new EmbedBuilder()
             .setColor('#9146FF')
             .setTitle(`🟣 Top clips are READY!`)
-            .setURL(`https://twitch.tv/${CONFIG.twitch.username}/videos?filter=clips&range=24hr`)
+            .setURL(`https://twitch.tv/${this.twitchUsername}/videos?filter=clips&range=24hr`)
             .addFields(fields)
             .setDescription(description)
-            .setImage(thumbnailUrl) 
+            .setImage(thumbnailUrl)
             .setTimestamp()
             .setFooter({ text: 'Twitch Top Clips' });
     }

--- a/src/services/discord.service.js
+++ b/src/services/discord.service.js
@@ -104,7 +104,8 @@ class DiscordService {
             commandList.push(
                 new SlashCommandBuilder().setName('mc-start').setDescription('Start Minecraft server'),
                 new SlashCommandBuilder().setName('mc-stop').setDescription('Stop Minecraft server'),
-                new SlashCommandBuilder().setName('mc-status').setDescription('Check Minecraft server status')
+                new SlashCommandBuilder().setName('mc-status').setDescription('Check Minecraft server status'),
+                new SlashCommandBuilder().setName('mc-restart').setDescription('Restart Minecraft server'),
             );
         }
 

--- a/src/services/discord.service.js
+++ b/src/services/discord.service.js
@@ -159,6 +159,10 @@ class DiscordService {
                     await this.craftyService.stopMinecraftServer();
                     await interaction.editReply('Minecraft server shutdown...');
                     break;
+                case 'mc-restart':
+                    await this.craftyService.restartMinecraftServer();
+                    await interaction.editReply('Minecraft server restarting...');
+                    break;
                 case 'mc-status':
                     const stats = await this.craftyService.getMinecraftServerInfo();
                     await interaction.editReply({ embeds: [this.buildMinecraftStatusEmbed(stats)] });

--- a/src/services/discord.service.js
+++ b/src/services/discord.service.js
@@ -165,7 +165,8 @@ class DiscordService {
                     await interaction.editReply('Minecraft server restarting...');
                     break;
                 case 'mc-status':
-                    const stats = await this.craftyService.getMinecraftServerInfo();
+                    const response = await this.craftyService.getMinecraftServerInfo();
+                    const stats = response?.data;
                     await interaction.editReply({ embeds: [this.buildMinecraftStatusEmbed(stats)] });
                     break;
             }
@@ -184,7 +185,7 @@ class DiscordService {
             .setTitle('Minecraft server')
             .addFields(
                 { name: 'Statut', value: stats.running ? 'Online' : 'Offline', inline: true },
-                { name: 'Players', value: `${stats.online_players || 0}/${stats.max_players || 0}`, inline: true }
+                { name: 'Players', value: `${stats.online || 0}/${stats.max || 0}`, inline: true }
             )
             .setTimestamp();
     }

--- a/src/services/monitor.service.js
+++ b/src/services/monitor.service.js
@@ -14,42 +14,44 @@ class MonitorService {
         this.discordService = discordService;
         this.isLive = false;
         this.checkInProgress = false;
-        this.checkInterval = null;
-        
-        // Use liveNotification config settings
-        this.username = CONFIG.twitch.username;
-        this.intervalTime = CONFIG.features.liveNotification.checkInterval;
-        this.isEnabled = CONFIG.features.liveNotification.isEnabled;
+        this.checkTimer = null;
+
+        // Use global config settings
+        this.twitchUsername = CONFIG.twitch.username;
+
+        // Use feature liveNotification config settings
+        this.liveNotificationCheckInterval = CONFIG.features.liveNotification.checkInterval;
+        this.liveNotificationsEnabled = CONFIG.features.liveNotification.isEnabled;
     }
 
     /**
      * Start the monitoring loop
      */
     start() {
-        if (!this.isEnabled) {
+        if (!this.liveNotificationsEnabled) {
             Logger.info('[MONITOR] Live notification feature is disabled.');
 
             return;
         }
         
-        Logger.info(`[MONITOR] Monitoring ${this.username} every ${this.intervalTime}ms`);
+        Logger.info(`[MONITOR] Monitoring ${this.twitchUsername} every ${this.liveNotificationCheckInterval}ms`);
         
         // First check immediately
         this.checkStreamStatus();
         
         // Schedule regular checks
-        this.checkInterval = setInterval(() => {
+        this.checkTimer = setInterval(() => {
             this.checkStreamStatus();
-        }, this.intervalTime);
+        }, this.liveNotificationCheckInterval);
     }
 
     /**
      * Stop the monitoring loop
      */
     stop() {
-        if (this.checkInterval) {
-            clearInterval(this.checkInterval);
-            this.checkInterval = null;
+        if (this.checkTimer) {
+            clearInterval(this.checkTimer);
+            this.checkTimer = null;
             Logger.info('[MONITOR] Monitoring stopped');
         }
     }
@@ -67,7 +69,7 @@ class MonitorService {
         this.checkInProgress = true;
 
         try {
-            const streamData = await this.twitchService.getStreamData(this.username);
+            const streamData = await this.twitchService.getStreamData(this.twitchUsername);
             await this.handleStreamStatusChange(streamData);
         } catch (error) {
             Logger.error('[MONITOR] Error checking stream status:', error.message);
@@ -95,11 +97,11 @@ class MonitorService {
             }
         } else if (!isNowLive && wasLive) {
             this.isLive = false;
-            Logger.info(`[MONITOR] ${this.username} stream has ended`);
+            Logger.info(`[MONITOR] ${this.twitchUsername} stream has ended`);
         } else if (isNowLive) {
             Logger.debug(`[MONITOR] ${streamData.user_name} is still live`);
         } else {
-            Logger.debug(`[MONITOR] ${this.username} is offline`);
+            Logger.debug(`[MONITOR] ${this.twitchUsername} is offline`);
         }
     }
 }

--- a/src/services/scheduler.service.js
+++ b/src/services/scheduler.service.js
@@ -14,19 +14,27 @@ class SchedulerService {
         this.twitchService = twitchService;
         this.discordService = discordService;
         this.scheduledTask = null;
+
+        // Use global config settings
+        this.twitchUsername = CONFIG.twitch.username;
+
+        // Use feature top clips config settings
+        this.topClipsIsEnabled = CONFIG.features.topClips.isEnabled;
+        this.topClipsSchedule = CONFIG.features.topClips.schedule;
+        this.topClipsCount = CONFIG.features.topClips.count;
     }
 
     /**
      * Start the scheduled tasks
      */
     start() {
-        if (!CONFIG.features.topClips.isEnabled) {
+        if (!this.topClipsIsEnabled) {
             Logger.info('Top clips job is disabled (TOP_CLIPS_CHANNEL_ID not set)');
 
             return;
         }
 
-        const schedule = CONFIG.features.topClips.schedule;
+        const schedule = this.topClipsSchedule;
         
         if (!cron.validate(schedule)) {
             Logger.error(`Invalid cron schedule: ${schedule}. Clips job will not run.`);
@@ -61,12 +69,9 @@ class SchedulerService {
     async runTopClipsJob() {
         Logger.info('[SCHEDULER] Running top clips job...');
         try {
-            const { username } = CONFIG.twitch;
-            const { count } = CONFIG.features.topClips;
-            
             const clips = await this.twitchService.getTopClips(
-                username,
-                count,
+                this.twitchUsername,
+                this.topClipsCount,
                 24 // Time period in hours
             );
 
@@ -75,7 +80,7 @@ class SchedulerService {
                 return;
             }
 
-            const topClips = clips.slice(0, count);
+            const topClips = clips.slice(0, this.topClipsCount);
             
             await this.discordService.sendTopClips(topClips);
         } catch (error) {

--- a/src/services/twitch.service.js
+++ b/src/services/twitch.service.js
@@ -11,8 +11,13 @@ class TwitchService {
         this.accessToken = null;
         this.tokenExpiresAt = null;
         this.userId = null;
-        this.baseURL = 'https://api.twitch.tv/helix';
-        this.authURL = 'https://id.twitch.tv/oauth2/token';
+        
+        // Use twitch config settings
+        this.apiBaseUrl = CONFIG.twitch.apiBaseUrl;
+        this.authUrl = CONFIG.twitch.authUrl;
+        this.clientId = CONFIG.twitch.clientId;
+        this.clientSecret = CONFIG.twitch.clientSecret;
+        this.username = CONFIG.twitch.username;
     }
 
     /**
@@ -36,15 +41,15 @@ class TwitchService {
 
         try {
             const response = await axios.post(
-                this.authURL,
+                this.authUrl,
                 null,
                 {
                     params: {
-                        client_id: CONFIG.twitch.clientId,
-                        client_secret: CONFIG.twitch.clientSecret,
+                        client_id: this.clientId,
+                        client_secret: this.clientSecret,
                         grant_type: 'client_credentials'
                     },
-                    timeout: CONFIG.api.requestTimeout
+                    timeout: CONFIG.apiSettings.requestTimeout
                 }
             );
 
@@ -75,16 +80,16 @@ class TwitchService {
         try {
             const token = await this.getAccessToken();
             const response = await axios.get(
-                `${this.baseURL}/users`,
+                `${this.apiBaseUrl}/users`,
                 {
                     headers: {
-                        'Client-ID': CONFIG.twitch.clientId,
+                        'Client-ID': this.clientId,
                         'Authorization': `Bearer ${token}`
                     },
                     params: {
                         login: username
                     },
-                    timeout: CONFIG.api.requestTimeout
+                    timeout: CONFIG.apiSettings.requestTimeout
                 }
             );
 
@@ -115,24 +120,24 @@ class TwitchService {
             const streamData = await withRetry(
                 async () => {
                     const response = await axios.get(
-                        `${this.baseURL}/streams`,
+                        `${this.apiBaseUrl}/streams`,
                         {
                             headers: {
-                                'Client-ID': CONFIG.twitch.clientId,
+                                'Client-ID': this.clientId,
                                 'Authorization': `Bearer ${token}`
                             },
                             params: {
                                 user_login: username
                             },
-                            timeout: CONFIG.api.requestTimeout
+                            timeout: CONFIG.apiSettings.requestTimeout
                         }
                     );
 
                     return response.data.data[0] || null;
                 },
                 {
-                    maxRetries: CONFIG.api.maxRetries,
-                    baseDelay: CONFIG.api.retryDelay
+                    maxRetries: CONFIG.apiSettings.maxRetries,
+                    baseDelay: CONFIG.apiSettings.retryDelay
                 }
             );
 
@@ -171,10 +176,10 @@ class TwitchService {
             const clipsData = await withRetry(
                 async () => {
                     const response = await axios.get(
-                        `${this.baseURL}/clips`,
+                        `${this.apiBaseUrl}/clips`,
                         {
                             headers: {
-                                'Client-ID': CONFIG.twitch.clientId,
+                                'Client-ID': this.clientId,
                                 'Authorization': `Bearer ${token}`
                             },
                             params: {
@@ -183,15 +188,15 @@ class TwitchService {
                                 ended_at: endTime,
                                 first: count
                             },
-                            timeout: CONFIG.api.requestTimeout
+                            timeout: CONFIG.apiSettings.requestTimeout
                         }
                     );
                     // Twitch API automatically sorts by views (which is perfect)
                     return response.data.data || [];
                 },
                 {
-                    maxRetries: CONFIG.api.maxRetries,
-                    baseDelay: CONFIG.api.retryDelay
+                    maxRetries: CONFIG.apiSettings.maxRetries,
+                    baseDelay: CONFIG.apiSettings.retryDelay
                 }
             );
 


### PR DESCRIPTION
## Related Issue
<!-- Reference the issue fixed or addressed by this PR. Example: Closes #1 -->
Closes #3 

## Description
<!-- Provide a clear summary of the changes, and other useful information -->
I have integrated [Crafty Controller API v2](https://docs.craftycontrol.com/pages/developer-guide/api-reference/v2/) to allow remote management of the Minecraft server directly from Discord.
The main changes of this PR include:
- Crafty integration: Created crafty.service.js and updated discord.service.js to handle all API communications.
- Server Control: Added commands /mc-start, /mc-stop, and /mc-restart.
- Real-time Status: Implemented /mc-status with a dynamic embed displaying the server state (Running/Offline) and player count.
- Documentation: Lightened the main README by adding CONTRIBUTING and ENV_SETUP.